### PR TITLE
add --synchronize and --no-synchronize flags to allow users to control tmux syncrhonize-panes behavior

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-TMUX_SESSION_NAME=$(tmux display-message -p "#S")
-
+# default environment variables
+SYNCHRONIZE_PANES=1
+TMUX_SESSION_NAME=$(tmux display-message -p "#S" 2> /dev/null)
 EXECUTABLE=${BASH_SOURCE[0]}
 
 if readlink ${EXECUTABLE} > /dev/null 2>&1; then
@@ -107,5 +108,9 @@ ensureTmuxSessionExists
 # ssh into matching nodes
 sshIntoNodes
 
-# synchronize panes
-synchronizePanes
+# properly set synchronize-panes
+if [ ${SYNCHRONIZE_PANES} -eq 1 ]; then
+    synchronizePanes
+else
+    unsynchronizePanes
+fi

--- a/parse-args.sh
+++ b/parse-args.sh
@@ -77,6 +77,12 @@ while :; do
 		--address-type=)
 			die '"--address-type" requires a non-empty option'
 			;;
+        --synchronize)
+            SYNCHRONIZE_PANES=1
+            ;;
+        --no-synchronize)
+            SYNCHRONIZE_PANES=0
+            ;;
         -h|--help)
             HELP_TEXT="$(cat <<-EOF
 Allows users to SSH into Kubernetes nodes by opening a new tmux pane for each matching node
@@ -95,8 +101,8 @@ EOF
 
             die "$HELP_TEXT"
             ;;
-		*)
-			break
+        *)
+            break
 	esac
 
 	shift


### PR DESCRIPTION
Rather than forcing users into synchronize-panes, add options to explicitly set or unset the behavior, defaulting to synchronize-panes enabled