### PR TITLE
Add containership-bot integration to detect stale issues and pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,13 @@
+daysUntilStale: 30
+daysUntilClose: false
+exemptLabels:
+  - status/blocked
+exemptProjects: false
+exemptMilestones: false
+exemptAssignees: false
+staleLabel: status/stale
+markComment: >
+  This issue has been automatically marked as stale due to lack of activity.
+  It may be closed by the maintainers if no further activity occurs.
+unmarkComment: >
+  Thank you for updating this issue. I will remove the stale label.


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Add integration with containership-bot such that stale issues and pull requests are marked as such with the `status/stale` label after 30 days.

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations
Duration can be revisited. Issues and pull requests marked as blocked will be ignored.

 ### Testing

 #### Setup
N/A

 #### Instructions
N/A

 ### Dependencies
N/A