### PR TITLE
Add -v and --version flags to report version

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # default environment variables
+KUBECTL_SSH_VERSION=0.0.2
 SYNCHRONIZE_PANES=1
 TMUX_SESSION_NAME=$(tmux display-message -p "#S" 2> /dev/null)
 EXECUTABLE=${BASH_SOURCE[0]}

--- a/parse-args.sh
+++ b/parse-args.sh
@@ -103,6 +103,10 @@ EOF
 
             die "$HELP_TEXT"
             ;;
+        -v|--version)
+            echo "$KUBECTL_SSH_VERSION"
+            exit
+            ;;
 
         # handle unknown arguments as positional and save for later use
         *)


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Provide rudimentary version reporting via hardcoded environment variable when user supplied `-v` or `--version` option.

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations
In the future, it may make sense to make this more robust and full-featured.

 ### Testing

 #### Setup
N/A

 #### Instructions
N/A

 ### Dependencies
N/A