### PR TITLE
Add common GitHub labels

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -76,3 +76,9 @@ labels:
   - name: Epic
     description: ZenHub Epic
     color: ffffff
+  - name: good first issue
+    description: Good for newcomers
+    color: 34fa00
+  - name: help wanted
+    description: Request for help from the community
+    color: 34fa00


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Add common GitHub labels `good first issue` and `help wanted` back to the repository

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations
N/A

 ### Testing

 #### Setup
N/A

 #### Instructions
N/A

 ### Dependencies
N/A